### PR TITLE
embed sourcemap in compiled source

### DIFF
--- a/lib/traceur-source-maps.js
+++ b/lib/traceur-source-maps.js
@@ -27,7 +27,12 @@ exports.install = function (traceur) {
     var compiledSource = compiler.compile(source);
 
     var sourceMapPath = getSourceMapPath(options.moduleName);
-    fs.writeFileSync(sourceMapPath, compiler.getSourceMap(), 'utf8');
+    var sourceMap = compiler.getSourceMap();
+    fs.writeFileSync(sourceMapPath, sourceMap, 'utf8');
+
+    var sourceMapBase64 = new Buffer(sourceMap.toString('base64'));
+    compiledSource += '\n//# sourceMappingURL=data:application/json;base64,' +
+      sourceMapBase64;
 
     return compiledSource;
   };


### PR DESCRIPTION
This will include the file source map in the compiled source,
as a result you can use node-inspector for debugging over the traceur code :dancers: 
