### PR TITLE
fixed incorrect source filename always <compileSource>

### DIFF
--- a/lib/traceur-source-maps.js
+++ b/lib/traceur-source-maps.js
@@ -24,7 +24,7 @@ exports.install = function (traceur) {
     options.sourceMaps = true;
 
     var compiler = new NodeCompiler(options);
-    var compiledSource = compiler.compile(source);
+    var compiledSource = compiler.compile(source, options.filename);
 
     var sourceMapPath = getSourceMapPath(options.moduleName);
     var sourceMap = compiler.getSourceMap();


### PR DESCRIPTION
``` bash
throw something exception like that 
    at serverRender (/Users/xxxx/Project/lib/<compileSource>:15:16)
    at /Users/xxx/Documents/Project/lib/<compileSource>:142:11
```

fixed this after 

``` bash
throw something exception like that 
    at serverRender (/Users/xxxx/Project/lib/application.js:15:16)
    at /Users/xxx/Documents/Project/lib/application.js:142:11
```
